### PR TITLE
[Enhancement] Implement QR code generation and scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.egg*
 .DS_Store
 *.zip
+.venv

--- a/octoprint_SpoolManager/api/SpoolManagerAPI.py
+++ b/octoprint_SpoolManager/api/SpoolManagerAPI.py
@@ -4,11 +4,13 @@ from __future__ import absolute_import
 import octoprint.plugin
 import datetime
 import flask
-from flask import jsonify, request, make_response, Response, send_file
+from flask import jsonify, request, make_response, Response, send_file, abort
 import json
 import shutil
 import tempfile
 import threading
+import qrcode
+from io import BytesIO     # for handling byte strings
 from math import pi as PI
 
 from octoprint_SpoolManager.models.SpoolModel import SpoolModel
@@ -276,6 +278,44 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 		return flask.jsonify({
 								"selectedSpool": spoolModelAsDict
 							})
+
+	#####################################################################################################   SELECT SPOOL BY QR
+	@octoprint.plugin.BlueprintPlugin.route("/QR/<id>", methods=["GET"])
+	def select_spool_qr(self,id):
+		self._logger.info("API select spool by QR code")
+
+		spoolModel = self._selectSpool(id)
+
+		spoolModelAsDict = None
+		if (spoolModel != None):
+			spoolModelAsDict = Transformer.transformSpoolModelToDict(spoolModel)
+			#Take us back to the SpoolManager plugin tab
+			return flask.redirect(flask.url_for("index", _external=True)+"#tab_plugin_SpoolManager",307)
+		else:
+			abort(404)
+
+
+	#####################################################################################################   GENERATE QR FOR SPOOL
+	@octoprint.plugin.BlueprintPlugin.route("/generateQR/<id>", methods=["GET"])
+	def generate_spool_qr(self,id):
+		if (self._databaseManager.loadSpool(id) is not None):
+			self._logger.info("API generate QR code for Spool")
+
+			qrMaker = qrcode.QRCode(
+				border=1,
+			)
+
+			qrMaker.add_data(flask.url_for("index", _external=True)+"/plugin/SpoolManager/QR/"+id)
+			qrMaker.make(fit=True)
+			qrImage = qrMaker.make_image(fill_color="darkgreen", back_color="white")
+
+			qr_io = BytesIO()
+			qrImage.save(qr_io, 'JPEG', quality=100)
+			qr_io.seek(0)
+
+			return send_file(qr_io, mimetype='image/jpeg')                                                
+		else:
+			abort(404)
 
 	######################################################################################   UPLOAD CSV FILE (in Thread)
 

--- a/octoprint_SpoolManager/static/css/SpoolManager.css
+++ b/octoprint_SpoolManager/static/css/SpoolManager.css
@@ -4,6 +4,11 @@
     margin-bottom:3px
 }
 
+.qr-code {
+    width: 100px;
+    height: 100px;
+}
+
 .debug-blue {
     outline: 1px solid blue;
 }

--- a/octoprint_SpoolManager/templates/SpoolManager_tab_dialogs.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_tab_dialogs.jinja2
@@ -241,6 +241,17 @@
                                 </div>
                             </div>
 
+                             <div class="control-group" data-bind="visible: spoolDialog.isExistingSpool">
+                                <label class="control-label">QR Code</label>
+                                <div class="controls">
+                                    <div class="">
+                                        <a data-bind="attr: {href: '/plugin/SpoolManager/generateQR/'+spoolDialog.spoolItemForEditing.databaseId()}" target="_new">
+                                            <img class="qr-code" alt="QR Code" data-bind="attr: {src: '/plugin/SpoolManager/generateQR/'+spoolDialog.spoolItemForEditing.databaseId() }">
+                                        </a>
+                                    </div>
+                               </div>
+                            </div>
+
 <!-- QR-Code scanner
                             <div class="control-group">
                                 <label class="control-label">QR/Bar-Code</label>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "OctoPrint-SpoolManager"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 #
-plugin_version = "1.2.0"
+plugin_version = "1.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -35,7 +35,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
-	"peewee"
+	"peewee","qrcode"
 ]
 
 ### --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Sometime ago I started playing around with the old Filament manager plugin trying to find a way to implement QR code scanning with minimal success. Having moved to SpoolManager (kudos on an awesome replacement btw) some time ago I finally decided to have another look at this and see if I could get it working.

I now have a proof of concept which generates QR codes which can be printed and then scanned  from any phone with a qr code reader to trigger a filament load. As an after thought I also redirect to the octoprint interface afterwards to allow immediate control (there might be something better to do here to confirm to the user the spool has been selected)

Alas I'm not a python programmer, so I suspect syntax/implementation could be improved but hopefully this can start a conversation for a useful feature (I can see it's already on the roadmap)

Changes
* Two new methods `/plugin/SpoolManager/generateQR/<databaseID>` and `/plugin/SpoolManager/QR/<databaseID>`
** `/generateQR` will return a jpg QR code with url encoded data for /QR for the given spool
** `/QR` will select and load the given spool and then redirect to the SpoolManager tab if successful
* Added QR code to spool edit screen to allow copying/printing
