### PR TITLE
Fix Uncaught TypeError: self.settingsViewModel.saveData() is undefined

### DIFF
--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -299,12 +299,11 @@ $(function() {
                 ){
                 var check = confirm('External database will not work. Save settings anyway?');
                 if (check == true) {
-                    origSaveSettingsFunction(data, successCallback, setAsSending);
+                    return origSaveSettingsFunction(data, successCallback, setAsSending);
                 }
-                return
+                return null;
             }
-            origSaveSettingsFunction(data, successCallback, setAsSending);
-            return;
+            return origSaveSettingsFunction(data, successCallback, setAsSending);
         }
         self.settingsViewModel.saveData = newSaveSettingsFunction;
 


### PR DESCRIPTION
Blocks the self.settingsViewModel.saveData of the wizard. 
See:  https://github.com/ralmn/OctoPrint-Ikea-tradfri/issues/39 