### PR TITLE
Fix extruder calculation with G2/G3

### DIFF
--- a/octoprint_SpoolManager/Odometer.py
+++ b/octoprint_SpoolManager/Odometer.py
@@ -47,7 +47,7 @@ class FilamentOdometer(object):
 		if gcode is None:
 			return
 
-		if gcode == "G1" or gcode == "G0":  # move
+		if gcode in ("G0", "G1", "G2", "G3"):  # move
 			e = self._get_float(cmd, self.regexE)
 			if e is not None:
 				if (e > 0.0):

--- a/octoprint_SpoolManager/newodometer.py
+++ b/octoprint_SpoolManager/newodometer.py
@@ -41,7 +41,7 @@ class NewFilamentOdometer(object):
         T = self._getCodeInt(line, "T")
 
         if G is not None:
-            if G == 0 or G == 1:  # Move
+            if G >= 0 and G <= 3:  # Move
                 x = self._getCodeFloat(line, "X")
                 y = self._getCodeFloat(line, "Y")
                 z = self._getCodeFloat(line, "Z")


### PR DESCRIPTION
When using this plugin with [Arc Welder](https://github.com/FormerLurker/ArcWelderPlugin) the extruded filament on arc moves was not calculated causing the final value to be lower than what the firmware reported.

This PR is a port from OllisGit/OctoPrint-FilamentManager#67 to SpoolManager.