### PR TITLE
make sidebar collapsible

### DIFF
--- a/octoprint_SpoolManager/static/css/SpoolManager.css
+++ b/octoprint_SpoolManager/static/css/SpoolManager.css
@@ -9,9 +9,6 @@
     height: 100px;
 }
 
-#sidebar_plugin_SpoolManager {
-    overflow: visible;
-}
 #selectedSpools > div {
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
remove unnecessary overflow:visible (#sidebar_plugin_SpoolManager) css rule because it overrides the visibility setting in the .collapse class.

This fixes issue #197 