### PR TITLE
Move button and dropdown menu in sidebar header [not complete]

### DIFF
--- a/octoprint_SpoolManager/__init__.py
+++ b/octoprint_SpoolManager/__init__.py
@@ -674,6 +674,7 @@ class SpoolmanagerPlugin(
 	def get_template_configs(self):
 		return [
 			dict(type="tab", name="Spools"),
+			dict(type="sidebar", name="Spool Manager", template_header="SpoolManager_sidebar_header.jinja2"),
 			dict(type="settings", custom_bindings=True, name="Spool Manager")
 		]
 

--- a/octoprint_SpoolManager/static/css/SpoolManager.css
+++ b/octoprint_SpoolManager/static/css/SpoolManager.css
@@ -9,9 +9,6 @@
     height: 100px;
 }
 
-#sidebar_plugin_SpoolManager {
-    overflow: visible;
-}
 #selectedSpools > div {
     display: flex;
     align-items: baseline;

--- a/octoprint_SpoolManager/templates/SpoolManager_sidebar.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_sidebar.jinja2
@@ -28,21 +28,6 @@
                 <button class="btn btn-mini" data-bind="click: $parent.editSpoolFromSidebar.bind($data, $index())" title="Edit Spool"><span class="icon-edit"></span></button>
                 <button class="btn btn-mini" data-bind="click: $parent.deselectSpoolForSidebar.bind($data, $index())" title="Deselect Spool"><span class="icon-remove"></span></button>
                 <!-- /ko -->
-
-                <button class="btn btn-mini dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
-
-                <ul class="dropdown-menu dropdown-menu-right" data-bind="foreach: $parent.allSpoolsForSidebar">
-                    <li>
-                        <a href="#" data-bind="click: $root.selectSpoolForSidebar.bind($data, $parentContext.$index())">
-                            <span class="color-preview" data-bind="style: {'background-color': $data.color}, attr: { title: $data.colorName }"></span>
-                            <span class="filament-label">
-                                <span><span data-bind="text: $data.material"></span> - <span data-bind="text: $data.displayName">FirstSpool</span></span>
-                                <span data-bind="text: $root.remainingText($data), attr: {title: $root.buildTooltipForSpoolItem($data, 'Remaining weight: ', 'remainingWeight')}" ></span>
-                            </span>
-                        </a>
-                    </li>
-                </ul>
-
             </div>
           </div>
       </div>

--- a/octoprint_SpoolManager/templates/SpoolManager_sidebar_header.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_sidebar_header.jinja2
@@ -1,0 +1,17 @@
+<div class="settings-trigger accordion-heading-button btn-group" data-bind="visible: $root.selectedSpoolsVisible">
+    <!-- I don't know how to make knockout work -->
+    <a class="dropdown-toggle" data-toggle="dropdown" href="#" title="Choose a spool">
+        <span class="fas fa-tape"></span>
+    </a>
+    <ul class="dropdown-menu" data-bind="foreach: $parent.allSpoolsForSidebar">
+        <li>
+            <a href="#" data-bind="click: $root.selectSpoolForSidebar.bind($data, $parentContext.$index())">
+                <span class="color-preview" data-bind="style: {'background-color': $data.color}, attr: { title: $data.colorName }"></span>
+                <span class="filament-label">
+                    <span><span data-bind="text: $data.material"></span> - <span data-bind="text: $data.displayName">FirstSpool</span></span>
+                    <span data-bind="text: $root.remainingText($data), attr: {title: $root.buildTooltipForSpoolItem($data, 'Remaining weight: ', 'remainingWeight')}" ></span>
+                </span>
+            </a>
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
Following commit #201 to fix issue #197 the dropdown menu is affected by overflow:hidden and is not fully visible anymore.
Moved it on the header so that it's not affected by that anymore.

I have no idea how knockout works, the menu now does not list any items, this has to be fixed. If possible, the icon should be hidden when the sidebar is collapsed.