### PR TITLE
Make sidebar collapsible

### DIFF
--- a/octoprint_SpoolManager/static/css/SpoolManager.css
+++ b/octoprint_SpoolManager/static/css/SpoolManager.css
@@ -9,7 +9,7 @@
     height: 100px;
 }
 
-#sidebar_plugin_SpoolManager {
+#sidebar_plugin_SpoolManager.collapse.in {
     overflow: visible;
 }
 #selectedSpools > div {


### PR DESCRIPTION
After looking at #201, I realise that simply removing the overflow won't do. Addresses #197 

Changing it to `#sidebar_plugin_SpoolManager.collapse.in` makes it work.