### PR TITLE
Decrease log level of events

### DIFF
--- a/octoprint_SpoolManager/__init__.py
+++ b/octoprint_SpoolManager/__init__.py
@@ -178,7 +178,7 @@ class SpoolmanagerPlugin(
 	def _sendPayload2EventBus(self, eventKey, eventPayload):
 
 		eventName = "plugin_spoolmanager_" + eventKey
-		self._logger.info("Send Event '"+eventName+"' with payload '"+str(eventPayload)+"' to event-bus")
+		self._logger.debug("Send Event '"+eventName+"' with payload '"+str(eventPayload)+"' to event-bus")
 		self._event_bus.fire(eventName, payload=eventPayload)
 
 	def _checkForMissingPluginInfos(self, sendToClient=False):


### PR DESCRIPTION
Any update to the UI triggers this log event - plugins which regularly update the UI cause this message to bloat the octoprint logs.

For an sample of this, see https://pastebin.com/8gc6Xh5Q