### PR TITLE
set qrcode package minimum required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ plugin_license = "AGPLv3"
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
 	"pillow >=6.2.0<7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
-	"qrcode",
+	"qrcode >=7.1", # required to support RGB colors, see https://github.com/lincolnloop/python-qrcode/pull/182
 	"peewee"
 	# "psycopg2-binary",  # postgres - driver
 	# "pymysql",	#mysql - driver


### PR DESCRIPTION
Pull to specify a minimum version for qrcode package to not get the same error as #260.

close #260