### PR TITLE
Add dropdown for existing purchasedFrom options

### DIFF
--- a/octoprint_SpoolManager/DatabaseManager.py
+++ b/octoprint_SpoolManager/DatabaseManager.py
@@ -1137,6 +1137,18 @@ class DatabaseManager(object):
 
 		return self._handleReusableConnection(databaseCallMethode, withReusedConnection, "loadCatalogColors", set())
 
+	def loadCatalogPurchasedFrom(self, withReusedConnection=False):
+		def databaseCallMethode():
+			result = set()
+			myQuery = SpoolModel.select(SpoolModel.purchasedFrom).distinct()
+			for spool in myQuery:
+				value = spool.purchasedFrom
+				if (value != None):
+					result.add(value)
+			return result
+
+		return self._handleReusableConnection(databaseCallMethode, withReusedConnection, "loadCatalogPurchasedFrom", set())
+
 	def deleteSpool(self, databaseId, withReusedConnection=False):
 		def databaseCallMethode():
 			with self._database.atomic() as transaction:  # Opens new transaction.

--- a/octoprint_SpoolManager/api/SpoolManagerAPI.py
+++ b/octoprint_SpoolManager/api/SpoolManagerAPI.py
@@ -886,6 +886,7 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 		materials = list(self._databaseManager.loadCatalogMaterials(tableQuery))
 		labels = list(self._databaseManager.loadCatalogLabels(tableQuery))
 		colors = list(self._databaseManager.loadCatalogColors(tableQuery))
+		purchasedFrom = list(self._databaseManager.loadCatalogPurchasedFrom(tableQuery))
 
 		materials = self._addAdditionalMaterials(materials)
 
@@ -902,6 +903,7 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 			"vendors": vendors,
 			"materials": materials,
 			"colors": colors,
+			"purchasedFrom": purchasedFrom,
 			"labels": labels
 		}
 		# catalogs = {

--- a/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
@@ -114,7 +114,7 @@ function SpoolManagerEditSpoolDialog(){
         this.purchasedOnKO = ko.observable();
 
 
-        this.purchasedFrom = ko.observable();
+        // this.purchasedFrom = ko.observable();
         this.cost = ko.observable();
         this.costUnit = ko.observable();
 
@@ -127,6 +127,10 @@ function SpoolManagerEditSpoolDialog(){
         var materialViewModel = self.componentFactory.createSelectWithFilter("spool-material-select", $('#spool-form'));
         this.material = materialViewModel.selectedOption;
         // this.allMaterials = materialViewModel.allOptions;
+
+        var purchasedFromViewModel = self.componentFactory.createSelectWithFilter("spool-purchasedFrom-select", $('#spool-form'));
+        this.purchasedFrom = purchasedFromViewModel.selectedOption;
+        this.allPurchasedFrom = purchasedFromViewModel.allOptions;
 
         // Autosuggest for "density"
         this.material.subscribe(function(newMaterial){
@@ -198,6 +202,9 @@ function SpoolManagerEditSpoolDialog(){
 
             //vendors
             this.allVendors(self.catalogs.vendors);
+
+            //purchasedFrom
+            this.allPurchasedFrom(self.catalogs.purchasedFrom);
         }
 
         this.selectedFromQRCode(updateData.selectedFromQRCode);
@@ -210,6 +217,7 @@ function SpoolManagerEditSpoolDialog(){
         this.isInActive(!updateData.isActive);
         this.displayName(updateData.displayName);
         this.vendor(updateData.vendor);
+        this.purchasedFrom(updateData.purchasedFrom);
 
         this.material(updateData.material);
         this.density(updateData.density);
@@ -334,6 +342,7 @@ function SpoolManagerEditSpoolDialog(){
     self.allMaterials = ko.observableArray([]);
     self.allVendors = ko.observableArray([]);
     self.allColors = ko.observableArray([]);
+    self.allPurchasedFrom = ko.observableArray([]);
 
     self.allToolIndices = ko.observableArray([]);
 
@@ -773,10 +782,12 @@ function SpoolManagerEditSpoolDialog(){
             self.allMaterials(self.catalogs["materials"]);
             self.allVendors(self.catalogs["vendors"]);
             self.allColors(self.catalogs["colors"]);
+            self.allPurchasedFrom(self.catalogs["purchasedFrom"]);
         } else {
             self.allMaterials([]);
             self.allVendors([]);
             self.allColors([]);
+            self.allPurchasedFrom([]);
         }
 
     }

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -355,7 +355,9 @@
                                 <div class="control-group no-bottom-gap">
                                     <label class="control-label">Purchased from</label>
                                     <div class="controls">
-                                        <input type="text" class="input-xlarge text-left" data-bind="value: spoolDialog.spoolItemForEditing.purchasedFrom"/>
+                                        <select id="spool-purchasedFrom-select" class="input-large" data-bind="options: spoolDialog.spoolItemForEditing.allPurchasedFrom, value: spoolDialog.spoolItemForEditing.purchasedFrom">
+                                        <option></option>
+                                        </select>
                                     </div>
                                 </div>
                                 <div class="control-group ">


### PR DESCRIPTION
#### Description

This PR adds a dropdown to the 'Purchased From' field, similar to what currently exists for vendor/material/color.

This can save time when entering new spools since I, and probably a lot of people, tend to only use a few filament suppliers.

#### Screenshot

![purchasedFrom-dropdown](https://user-images.githubusercontent.com/7365747/179297036-3f1920d4-404a-4c67-b76f-69785f6c56c3.png)

#### Further Notes

Thoughts are appreciated.

