### PR TITLE
Fix breaking dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
-	"pillow >=6.2.0<7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
+	"pillow",
 	"qrcode",
 	"peewee"
 	# "psycopg2-binary",  # postgres - driver


### PR DESCRIPTION
Remove version restraint of the pillow packages as it was breaking the plugin on Octoprint 1.8.1 installations. Python 2 is no longer supported by Octoprint so there's no point in this plugin supporting it.