### PR TITLE
Fixes for Template Copy

### DIFF
--- a/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
@@ -865,9 +865,8 @@ function SpoolManagerEditSpoolDialog(){
         // reset values that should'nt be copied
 
 
-        var defaultExcludedFields = ["selectedForTool","version", "databaseId", "isTemplate","firstUseKO", "lastUseKO",
-                                    "remainingWeight","remainingPercentage","usedLength", "usedLengthPercentage","remainingLength", "remainingLengthPercentage",
-                                    "usedWeight", "usedPercentage"];
+        var defaultExcludedFields = ["selectedForTool", "version", "firstUseKO", "lastUseKO", "remainingWeight", "remainingPercentage", "usedLength", 
+                                    "usedLengthPercentage", "remainingLength", "remainingLengthPercentage", "usedWeight", "usedPercentage"];
         var allFieldNames = Object.keys(spoolItem);
         for (const fieldName of allFieldNames){
             if (self.pluginSettings.excludedFromTemplateCopy().includes(fieldName) ||

--- a/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
@@ -864,8 +864,7 @@ function SpoolManagerEditSpoolDialog(){
         self._copySpoolItemForEditing(spoolItem);
         // reset values that should'nt be copied
 
-
-        var defaultExcludedFields = ["selectedForTool", "version", "firstUseKO", "lastUseKO", "remainingWeight", "remainingPercentage", "usedLength", 
+        var defaultExcludedFields = ["selectedForTool", "version", "firstUseKO", "lastUseKO", "remainingWeight", "remainingPercentage", 
                                     "usedLengthPercentage", "remainingLength", "remainingLengthPercentage", "usedWeight", "usedPercentage"];
         var allFieldNames = Object.keys(spoolItem);
         for (const fieldName of allFieldNames){
@@ -884,6 +883,8 @@ function SpoolManagerEditSpoolDialog(){
             // self.spoolItemForEditing["noteHtml"]("");
         }
 
+        self.spoolItemForEditing.usedLength(0);
+        
         // close dialog
         self.templateSpoolDialog.modal('hide');
     }

--- a/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
@@ -873,7 +873,7 @@ function SpoolManagerEditSpoolDialog(){
             if (self.pluginSettings.excludedFromTemplateCopy().includes(fieldName) ||
                 defaultExcludedFields.includes(fieldName)){
                 var currentValue = self.spoolItemForEditing[fieldName]();
-                self.spoolItemForEditing[fieldName]("");
+                self.spoolItemForEditing[fieldName](null);
             }
         }
         if (self.pluginSettings.excludedFromTemplateCopy().includes("allNotes")) {

--- a/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-EditSpoolDialog.js
@@ -867,7 +867,7 @@ function SpoolManagerEditSpoolDialog(){
 
         var defaultExcludedFields = ["selectedForTool","version", "databaseId", "isTemplate","firstUseKO", "lastUseKO",
                                     "remainingWeight","remainingPercentage","usedLength", "usedLengthPercentage","remainingLength", "remainingLengthPercentage",
-                                    "usedWeight", "usedPercentage", "totalCombinedWeight", "remainingCombinedWeight"];
+                                    "usedWeight", "usedPercentage"];
         var allFieldNames = Object.keys(spoolItem);
         for (const fieldName of allFieldNames){
             if (self.pluginSettings.excludedFromTemplateCopy().includes(fieldName) ||


### PR DESCRIPTION
Includes fixes to address problem from #294 

Also fixes a secondary nuisance when copying templates -- totalCombinedWeight/remainingCombinedWeight are calculated during the copy, but were then set to null, in order to save the spool one had to make a meaningless edit to one of the weight fields so it would calculate again.