### PR TITLE
fix: pillow version string in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
-	"pillow >=6.2.0<7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
+	"pillow >=6.2.0,<7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
 	"qrcode",
 	"peewee"
 	# "psycopg2-binary",  # postgres - driver


### PR DESCRIPTION
when trying to install spoolmanager i got those errors in the plugin_pluginmanager_console.log. 
It seems there was a "," missing in the pillow version string.
Now installation works.

plugin_pluginmanager_console.log:

—————
```
...
2023-04-27 13:06:28,668 ! Traceback (most recent call last):
2023-04-27 13:06:28,668 ! File "<string>", line 2, in <module>
2023-04-27 13:06:28,668 ! File "<pip-setuptools-caller>", line 34, in <module>
2023-04-27 13:06:28,669 ! File "/tmp/pip-req-build-bkevnds4/setup.py", line 103, in <module>
2023-04-27 13:06:28,669 ! setup(**setup_parameters)
2023-04-27 13:06:28,669 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/__init__.py", line 108, in setup
2023-04-27 13:06:28,670 ! return distutils.core.setup(**attrs)
2023-04-27 13:06:28,670 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-04-27 13:06:28,670 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
2023-04-27 13:06:28,670 ! return run_commands(dist)
2023-04-27 13:06:28,671 ! ^^^^^^^^^^^^^^^^^^
2023-04-27 13:06:28,671 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
2023-04-27 13:06:28,672 ! dist.run_commands()
2023-04-27 13:06:28,672 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
2023-04-27 13:06:28,672 ! self.run_command(cmd)
2023-04-27 13:06:28,673 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/dist.py", line 1213, in run_command
2023-04-27 13:06:28,673 ! super().run_command(command)
2023-04-27 13:06:28,673 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
2023-04-27 13:06:28,674 ! cmd_obj.run()
2023-04-27 13:06:28,674 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/bdist_wheel.py", line 395, in run
2023-04-27 13:06:28,674 ! self.egg2dist(self.egginfo_dir, distinfo_dir)
2023-04-27 13:06:28,674 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/bdist_wheel.py", line 534, in egg2dist
2023-04-27 13:06:28,675 ! pkg_info = pkginfo_to_metadata(egginfo_path, pkginfo_path)
2023-04-27 13:06:28,675 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-04-27 13:06:28,675 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/metadata.py", line 160, in pkginfo_to_metadata
2023-04-27 13:06:28,676 ! for key, value in generate_requirements({extra: reqs}):
2023-04-27 13:06:28,676 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/metadata.py", line 138, in generate_requirements
2023-04-27 13:06:28,677 ! for new_req in convert_requirements(depends):
2023-04-27 13:06:28,677 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/metadata.py", line 103, in convert_requirements
2023-04-27 13:06:28,677 ! parsed_requirement = Requirement(req)
2023-04-27 13:06:28,678 ! ^^^^^^^^^^^^^^^^
2023-04-27 13:06:28,678 ! File "/home/ender/OctoPrint/venv/lib/python3.11/site-packages/wheel/vendored/packaging/requirements.py", line 37, in __init__
2023-04-27 13:06:28,679 ! raise InvalidRequirement(str(e)) from e
2023-04-27 13:06:28,679 ! wheel.vendored.packaging.requirements.InvalidRequirement: Expected end or semicolon (after version specifier)
2023-04-27 13:06:28,680 ! pillow>=6.2.0<7.0.0
2023-04-27 13:06:28,680 ! ~~~~~~~^
2023-04-27 13:06:28,680 ! [end of output]
2023-04-27 13:06:28,681 !
2023-04-27 13:06:28,681 ! note: This error originates from a subprocess, and is likely not a problem with pip.
2023-04-27 13:06:28,681 ! ERROR: Failed building wheel for OctoPrint-SpoolManager
2023-04-27 13:06:31,125 ! ERROR: Could not build wheels for OctoPrint-SpoolManager, which is required to install pyproject.toml-based projects
2023-04-27 13:06:31,628 > Failed to build OctoPrint-SpoolManager
```
—————